### PR TITLE
set_parameters_callback removed in Galactic

### DIFF
--- a/rclpy/parameters.md
+++ b/rclpy/parameters.md
@@ -29,7 +29,7 @@ class MyNode(Node):
         self.declare_parameter("my_param_name", 42)
 
         # Then create callback
-        self.set_parameters_callback(self.callback)
+        self.add_on_set_parameters_callback(self.callback)
     
     def callback(self, parameters):
         result = SetParametersResult(successful=True)


### PR DESCRIPTION
replaced with add_on_set_parameters_callback, see[ changelog description](https://docs.ros.org/en/humble/Releases/Release-Galactic-Geochelone.html#removal-of-deprecated-node-set-parameters-callback)